### PR TITLE
Fix verify_script, and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+bitcoinconsensus_testcases
 .idea
 nbproject
 composer.lock
@@ -29,6 +30,4 @@ mkinstalldirs
 run-tests.php
 tags
 vendor
-
-
-
+CMakeLists.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
         cd bitcoinconsensus \
         && phpize && ./configure && make && sudo make install \
         && cd ..
-    - git clone git@github.com:jonasnick/bitcoinconsensus_tests
+    - git clone https://github.com/jonasnick/bitcoinconsensus_testcases.git
     - composer update
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
         cd bitcoinconsensus \
         && phpize && ./configure && make && sudo make install \
         && cd ..
+    - git clone git@github.com:jonasnick/bitcoinconsensus_tests
     - composer update
 
 before_script:

--- a/bitcoinconsensus/bitcoinconsensus.c
+++ b/bitcoinconsensus/bitcoinconsensus.c
@@ -32,13 +32,14 @@ PHP_FUNCTION(bitcoinconsensus_verify_script)
     unsigned char *scriptPubKey, *transaction;
     int scriptPubKeyLen, transactionLen;
     unsigned int nInput, flags;
-    zval scriptErr;
-    bitcoinconsensus_error *error;
+    zval *scriptErr;
+    bitcoinconsensus_error error;
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ssllz", &scriptPubKey, &scriptPubKeyLen, &transaction, &transactionLen, &nInput, &flags, &scriptErr) == FAILURE) {
         return;
     }
 
-    int result = bitcoinconsensus_verify_script(scriptPubKey, scriptPubKeyLen, transaction, transactionLen, nInput, flags, error);
+    int result = bitcoinconsensus_verify_script(scriptPubKey, scriptPubKeyLen, transaction, transactionLen, nInput, flags, &error);
+    ZVAL_LONG(scriptErr, error);
     RETURN_LONG(result);
 }
 /* }}} */

--- a/tests/BitcoinConsensusTest.php
+++ b/tests/BitcoinConsensusTest.php
@@ -6,7 +6,7 @@ class BitcoinConsensusTest extends \PHPUnit_Framework_TestCase
 {
     private function loadExternalTestFiles($dir)
     {
-        $results = [];
+        $results = array();
         $basedir = __DIR__ . '/../bitcoinconsensus_testcases/';
         $fulldir = $basedir . $dir . '/';
         foreach (scandir($fulldir) as $file) {
@@ -19,7 +19,7 @@ class BitcoinConsensusTest extends \PHPUnit_Framework_TestCase
     }
 
     private function loadVectors($dir) {
-        $vectors = [];
+        $vectors = array();
         foreach ($this->loadExternalTestFiles($dir) as $c => $file) {
             $vectors[] = array_merge(array($dir, $c), explode("\n", file_get_contents($file)));
         }

--- a/tests/BitcoinConsensusTest.php
+++ b/tests/BitcoinConsensusTest.php
@@ -10,7 +10,7 @@ class BitcoinConsensusTest extends \PHPUnit_Framework_TestCase
         $basedir = __DIR__ . '/../bitcoinconsensus_testcases/';
         $fulldir = $basedir . $dir . '/';
         foreach (scandir($fulldir) as $file) {
-            if (in_array($file, ['.','..'])) {
+            if (in_array($file, array('.','..'))) {
                 continue;
             }
             $results[] = $fulldir . $file;
@@ -21,8 +21,7 @@ class BitcoinConsensusTest extends \PHPUnit_Framework_TestCase
     private function loadVectors($dir) {
         $vectors = [];
         foreach ($this->loadExternalTestFiles($dir) as $c => $file) {
-            $v = array_merge([$dir, $c], explode("\n", file_get_contents($file)));
-            $vectors[] = $v;
+            $vectors[] = array_merge(array($dir, $c), explode("\n", file_get_contents($file)));
         }
         return $vectors;
     }

--- a/tests/BitcoinConsensusTest.php
+++ b/tests/BitcoinConsensusTest.php
@@ -4,8 +4,63 @@ namespace BitWasp\BitcoinConsensus\Tests;
 
 class BitcoinConsensusTest extends \PHPUnit_Framework_TestCase
 {
+    private function loadExternalTestFiles($dir)
+    {
+        $results = [];
+        $basedir = __DIR__ . '/../bitcoinconsensus_testcases/';
+        $fulldir = $basedir . $dir . '/';
+        foreach (scandir($fulldir) as $file) {
+            if (in_array($file, ['.','..'])) {
+                continue;
+            }
+            $results[] = $fulldir . $file;
+        }
+        return $results;
+    }
+
+    private function loadVectors($dir) {
+        $vectors = [];
+        foreach ($this->loadExternalTestFiles($dir) as $c => $file) {
+            $v = array_merge([$dir, $c], explode("\n", file_get_contents($file)));
+            $vectors[] = $v;
+        }
+        return $vectors;
+    }
+
+    public function getNegativeTests()
+    {
+        return $this->loadVectors('0.10-negative');
+    }
+
+    public function getPositiveTests()
+    {
+        return $this->loadVectors('0.10-positive');
+    }
+
+    public function getAllTests()
+    {
+        return array_merge($this->getPositiveTests(), $this->getNegativeTests());
+    }
     public function testVersion()
     {
         $this->assertEquals(0, bitcoinconsensus_version());
+    }
+
+    /**
+     * @dataProvider getAllTests
+     */
+    public function testValid($dir, $c, $scriptHex, $txHex, $nInput, $flags, $eResult)
+    {
+        $script = pack("H*", $scriptHex);
+        $tx = pack("H*", $txHex);
+
+        $error = 0;
+        $result = bitcoinconsensus_verify_script($script, $tx, $nInput, $flags, $error);
+        $this->assertEquals($eResult, $result, $dir . "/" . $c);
+
+        // since the script returns true, the error can never be zero.
+        if ($eResult == 1) {
+            $this->assertEquals(0, $error);
+        }
     }
 }


### PR DESCRIPTION
`zval scriptErr` should have been `zval *scriptErr`
`bitcoinconsensus_error *error` should have been `bitcoinconsensus_error`

Testing against jonasnick/bitcoinconsensus_testcases since it turns up some interesting edge cases in other implementations. 

Since these were generated against libbitcoinconsensus, none should fail, but includes some cases that exploits weaker type handling in other implementations, so should be a good set to stick to.
