### PR TITLE
build 7.2 and nightly - 5.3 isn't supported by travis on this build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,25 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
+    - nightly
 
 env:
-  - BITCOIN_VERSION=0.13.2
-  - BITCOIN_VERSION=0.14.0
-  - BITCOIN_VERSION=0.14.2
+  - BITCOIN_VERSION=0.16.1
+
+matrix:
+  include:
+    - php: 7.2
+      env: BITCOIN_VERSION=0.13.2
+    - php: 7.2
+      env: BITCOIN_VERSION=0.14.2
+    - php: 7.2
+      env: BITCOIN_VERSION=0.15.1
 
 install:
     - |


### PR DESCRIPTION
test other bitcoin versions in single php version

cleans up the state of testing in 2.0.0