### PR TITLE
test on 7.3, and include 0.17.0 in bitcoin tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: php
 
+dist: xenial
+
 php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 env:
@@ -23,6 +26,8 @@ matrix:
     - php: 7.2
       env: BITCOIN_VERSION=0.16.3 COVERAGE=true
     - php: 7.2
+      env: BITCOIN_VERSION=0.17.0
+    - php: 7.2
       env: BITCOIN_VERSION=0.13.2
     - php: 7.2
       env: BITCOIN_VERSION=0.14.3
@@ -34,7 +39,7 @@ before_install:
 
 install:
   - |
-      wget https://bitcoin.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
+      wget https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
       && tar xvf bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz \
       && cd bitcoin-${BITCOIN_VERSION} \
       && sudo cp include/bitcoinconsensus.h /usr/include/ \


### PR DESCRIPTION
Adds a test run for 7.3, since nightly now refers to 7.4.

Adds a test against bitcoin 0.17.0, which lead to some problems actually. https://0bin.net/paste/tn5+jDc7mpPyKQ6s#xA4aTuemo31wSJbC1vVJ5xcQ3QBFxXmbu62YBZhphWh

The 0.17.0 distribution was built with a newer compiler it seems, so bumping travis to xenial was enough of a 'fix' for me. 